### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ PUI-react uses the CommonJS pattern of requiring modules to use components.
 To load the components for use in a browser, you will need a build tool like Webpack or Browserify.
 We also require ReactJS. The specific version is listed in our peer dependencies.
 
+For development, we have dependencies on:
+
+* **PhantomJS**: Used for running our headless Jasmine tests. Install via `brew install phantomjs`
+* **node-foreman**: Used for running our asset-compilation and jasmine server during development. Install via `npm install -g node-foreman`
+
 ## Development
 
 This library is intimately tied to Pivotal UI and development should be done on the Pivotal UI [styleguide](styleguide.pivotal.io).

--- a/README.md
+++ b/README.md
@@ -56,23 +56,8 @@ npm link ../pivotal-ui-react/dist/tooltip
 ```
 
 ##Testing
- 
+
 To test the react components:
 ```sh
 gulp jasmine-ci
 ```
-
-To test Dr Frankenstyle:
-
-The first time you test, you need to install Dr Frankenstyle dependencies:
-```sh
-cd dr-frankenstyle
-npm install
-```
-
-Run all Dr Frankenstyle tests, from the root directory:
-```sh
-jasmine
-```
-
-


### PR DESCRIPTION
Before trying to work on any PR's for React components, we found that there were a few undocumented dependencies in the README that we had to track down (and the error output from npm was not useful). This just mentions what those dependencies are, and how to install them.

Also, I was a bit confused about why there was Dr Frankenstyle testing documentation in this README -- I removed it since it seemed out of place, but I may have been a bit over-zealous.

Cheers!
